### PR TITLE
Update XState to 4.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "react-ace": "^6.2.0",
     "react-dom": "^16.6.0",
     "styled-components": "^4.0.2",
-    "xstate": "^4.0.1"
+    "xstate": "^4.2.4"
   }
 }


### PR DESCRIPTION
The version of XState in the visualiser appears to not be the latest. In particular, it doesn't seem to support callback-style services.

The package-lock will need regenerating.