### PR TITLE
fix: mark className prop optional on StateChart

### DIFF
--- a/src/StateChart.tsx
+++ b/src/StateChart.tsx
@@ -121,7 +121,7 @@ function Field({ label, children, disabled, style }: FieldProps) {
 }
 
 interface StateChartProps {
-  className: string;
+  className?: string;
   machine: StateNode<any> | string;
   height?: number | string;
 }


### PR DESCRIPTION
👋 I run into the following error when try running `npm run develop`:
```
~/projects/xstate-viz/public/src/App.tsx
[1] Type error: Type '{ machine: string; }' is not assignable to type 'Readonly<StateChartProps>'.
[1]   Property 'className' is missing in type '{ machine: string; }'.  TS2322
```

If I understand correctly, it looks like the fix is just a one character change to mark the new `className` prop optional on the `StateChart` component.