### PR TITLE
Allow custom filename when loading from gist

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -532,8 +532,8 @@ const appMachine = Machine<AppMachineContext>(
                 actions: assign<AppMachineContext>({
                   gist: (_, e) => e.data,
                   // @ts-ignore
-                  machine: (_, e) => {
-                    return e.data.files['machine.js'].content;
+                  machine: (ctx, e) => {
+                    return e.data.files[ctx.query.file || 'machine.js'].content;
                   }
                 })
               },


### PR DESCRIPTION
It implements the proposal emerged in #21:
it's possible to specify a custom file name within the gist by passing a `&file=...` URL param.

The `file` param name could be debatable...