### PR TITLE
Remember node toggle state

### DIFF
--- a/src/Edge.tsx
+++ b/src/Edge.tsx
@@ -375,6 +375,7 @@ export class Edge extends Component<EdgeProps, EdgeState> {
               const fill = i > pts.length ? 'red' : 'blue';
               return (
                 <circle
+                  key={i}
                   cx={circle.x}
                   cy={circle.y}
                   r={i > pts.length ? 0.5 : 1}

--- a/src/StateChartNode.tsx
+++ b/src/StateChartNode.tsx
@@ -459,10 +459,20 @@ interface StateChartNodeProps {
   level: number;
 }
 
-export class StateChartNode extends React.Component<StateChartNodeProps> {
-  state = {
-    toggled: true
-  };
+interface StateChartNodeState {
+  toggled: boolean
+}
+
+export class StateChartNode extends React.Component<StateChartNodeProps, StateChartNodeState> {
+  constructor(props: StateChartNodeProps) {
+    super(props);
+
+    // get toggled value from localStorage
+    const toggledValue = localStorage.getItem(`${props.stateNode.id}_toggled`);
+    const toggled = toggledValue === null || toggledValue === '1';
+    this.state = { toggled };
+  }
+
 
   stateRef = React.createRef<any>();
 
@@ -600,7 +610,12 @@ export class StateChartNode extends React.Component<StateChartNodeProps> {
               title={this.state.toggled ? 'Hide children' : 'Show children'}
               onClick={e => {
                 e.stopPropagation();
-                this.setState({ toggled: !this.state.toggled }, () => {
+                
+                // remember toggled value
+                const toggled = !this.state.toggled;
+                localStorage.setItem(`${stateNode.id}_toggled`, toggled ? '1' : '');
+
+                this.setState({ toggled }, () => {
                   tracker.updateAll();
                 });
               }}


### PR DESCRIPTION
This pull request adds the feature of remembering node's toggle state (in localStorage). So that when user refreshes the visualizer page, collapsed nodes will remain collapse. This is very useful for visualizing and editing a large state machine.