### PR TITLE
Use typescript transpile module in editor

### DIFF
--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -67,9 +67,9 @@ export const EditorRenderer: React.FunctionComponent<EditorProps> = props => {
             keybindings: [
               MonacoEditor.KeyMod.CtrlCmd | MonacoEditor.KeyCode.KEY_R
             ],
-            run: ed => {
+            run: value => {
               if (typeof onSave === "function") {
-                onChange(ed.getValue());
+                onChange(value);
               }
             }
           }

--- a/src/MonacoEditor.tsx
+++ b/src/MonacoEditor.tsx
@@ -1,18 +1,41 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useState } from "react";
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 import { KeyCode, KeyMod } from "monaco-editor";
 import { format } from "prettier/standalone";
 import tsParser from "prettier/parser-typescript";
+import * as ts from "typescript";
+import { hashString } from "./utils";
+
+// TODO: use this to implement undo (CMD + Z) in the editor
+const UNDO_TRACKER = 4;
+const lscache = {
+  __store: new Map(),
+  get(key: string) {
+    const data = this.__store.get(key);
+    return data || null;
+  },
+  set(key: string, value: string) {
+    const keys = Array.from(this.__store.keys());
+    while (this.__store.size >= UNDO_TRACKER) {
+      // Remove from top (FIFO)
+      this.__store.delete(keys[0]);
+    }
+    this.__store.set(key, value);
+  }
+};
 
 type Def = { fileName: string; content: string };
 
+type EditorAction = Omit<monaco.editor.IActionDescriptor, "run"> & {
+  run: (value: string) => void;
+};
 type MonacoEditorProps = {
   value: string;
   onChange: (code: string) => void;
   definitions: Def[] | undefined;
   height?: string;
   mode?: string;
-  registerEditorActions?: monaco.editor.IActionDescriptor[];
+  registerEditorActions?: EditorAction[];
 };
 
 function prettify(code: string) {
@@ -23,34 +46,26 @@ function prettify(code: string) {
 }
 
 export function MonacoEditor(props: MonacoEditorProps) {
-  let subscription: monaco.IDisposable;
   const editorRef = useRef<HTMLDivElement>(null!);
-  let editor: monaco.editor.IStandaloneCodeEditor;
-
   /**
    * In case editor is controlled in future, this needs to be changed to `useLayoutEffect`
    * to avoid stale values considering React batches state updates and effect execution
    */
   useEffect(() => {
-    const {
-      value,
-      onChange,
-      mode = "javascript",
-      registerEditorActions = []
-    } = props;
+    const { value, onChange, registerEditorActions = [] } = props;
     const definitions = props.definitions as Def[];
 
     // Register definition files in the lib registry
     for (const file of definitions) {
       const fakePath = `file:///node_modules/@types/xstate/${file.fileName}`;
-      monaco.languages.typescript.javascriptDefaults.addExtraLib(
+      monaco.languages.typescript.typescriptDefaults.addExtraLib(
         file.content,
         fakePath
       );
     }
 
     // Expose required methods from xstate to globals in order to avoid users from using scoped methods.
-    monaco.languages.typescript.javascriptDefaults.addExtraLib(
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
       `
           import * as _XState from "xstate";
 
@@ -67,14 +82,17 @@ export function MonacoEditor(props: MonacoEditorProps) {
       "file:///global.d.ts"
     );
 
+    // Restore TS source from the cache if it's available
+    const modelValue = lscache.get(hashString(value)) || value;
+
     const model = monaco.editor.createModel(
-      value,
-      mode,
+      modelValue,
+      "typescript",
       monaco.Uri.parse("file:///main.tsx")
     );
 
-    editor = monaco.editor.create(editorRef.current, {
-      language: mode,
+    const editor = monaco.editor.create(editorRef.current, {
+      language: "typescript",
       minimap: { enabled: false },
       lineNumbers: "off",
       scrollBeyondLastLine: false,
@@ -98,11 +116,16 @@ export function MonacoEditor(props: MonacoEditorProps) {
 
     // Register custom actins passed to the editor
     registerEditorActions.forEach(action => {
-      editor.addAction(action);
+      editor.addAction({
+        ...action,
+        run: ed => {
+          action.run(ts.transpileModule(ed.getValue(), {}).outputText);
+        }
+      });
     });
 
     // Register formatting action using Prettier
-    monaco.languages.registerDocumentFormattingEditProvider("javascript", {
+    monaco.languages.registerDocumentFormattingEditProvider("typescript", {
       provideDocumentFormattingEdits: model => {
         try {
           return [
@@ -118,7 +141,7 @@ export function MonacoEditor(props: MonacoEditorProps) {
     });
 
     monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
-      allowJs: true,
+      allowJs: false,
       typeRoots: ["node_modules/@types"],
       target: monaco.languages.typescript.ScriptTarget.ES2016,
       allowNonTsExtensions: true,
@@ -131,8 +154,11 @@ export function MonacoEditor(props: MonacoEditorProps) {
     editor.getAction("editor.action.formatDocument").run();
 
     // Subscribe to editor model content change
-    subscription = editor.onDidChangeModelContent(() => {
-      props.onChange(editor.getValue());
+    const subscription = editor.onDidChangeModelContent(() => {
+      const editorValue = editor.getValue();
+      const output = ts.transpileModule(editorValue, {});
+      lscache.set(hashString(output.outputText), editorValue);
+      props.onChange(output.outputText);
     });
 
     return () => {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -139,3 +139,14 @@ export function isBuiltInEvent(eventType: string): boolean {
     eventType === ''
   );
 }
+
+export function hashString(str: string) {
+  return str
+    .split("")
+    .reduce(
+      (prevHash, currVal) =>
+        ((prevHash << 5) - prevHash + currVal.charCodeAt(0)) | 0,
+      0
+    )
+    .toString();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "resolveJsonModule": true,
     "lib": ["dom", "es7"],
     "outDir": "./lib",
-    "declaration": true
+    "declaration": true,
+    "downlevelIteration": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
This fix includes:
- use `ts` package to transpile the code
- separate editor source (TS) and transpiled JS to avoid content replacement on updates
- hash editor content and keep track of previous contents by using a simple FIFO caching mechanism. this hash is used to restore the source based on the updated value coming from the parent component. updates happen in `Statechart` component which evaluates machines and visualizes them.
- decorates editor actions to have access to the transpiled content