### PR TITLE
Issue 32: fix crash on empty event.type

### DIFF
--- a/src/StateChartAction.tsx
+++ b/src/StateChartAction.tsx
@@ -94,7 +94,9 @@ export const StateChartAction: React.SFC<StateChartActionProps> = ({
     case actionTypes.send:
       const sendAction = action as SendActionObject<any, any>;
 
-      if (sendAction.event.type.indexOf('xstate.after') === 0) {
+      if (
+        sendAction.event.type &&
+        sendAction.event.type.indexOf('xstate.after') === 0) {
         return null;
       }
 


### PR DESCRIPTION
Fixes https://github.com/statecharts/xstate-viz/issues/32