### PR TITLE
fix event on guards

### DIFF
--- a/src/StateChartGuard.tsx
+++ b/src/StateChartGuard.tsx
@@ -9,10 +9,11 @@ const StyledSCGuard = styled.div`
 export const StateChartGuard: React.SFC<{
   guard: Guard<any, any>;
   state: State<any>;
-}> = ({ guard, state }) => {
+  event: string
+}> = ({ guard, state, event }) => {
   const valid =
     guard.predicate && typeof guard.predicate === 'function'
-      ? guard.predicate(state.context, state.event, { cond: guard })
+      ? guard.predicate(state.context, {type: event}, { cond: guard })
       : undefined;
 
   return (

--- a/src/StateChartNode.tsx
+++ b/src/StateChartNode.tsx
@@ -696,6 +696,7 @@ export const StateChartNode: React.FC<StateChartNodeProps> = props => {
                   <StateChartGuard
                     guard={edge.transition.cond}
                     state={current}
+                    event={ownEvent}
                   />
                 )}
               </StyledEventButton>


### PR DESCRIPTION
Hi, while playing with guards I realized, that visualizer used `state.event` which don't contain correct event, so I try to fix it.